### PR TITLE
Corrected error in how LinerNDInterpolator was called in the Local Range...

### DIFF
--- a/ion_functions/qc/qc_functions.py
+++ b/ion_functions/qc/qc_functions.py
@@ -205,16 +205,13 @@ def dataqc_localrangetest(dat, z, datlim, datlimz, strict_validation=False):
     else:
         # Compute Delaunay Triangulation and use linear interpolation to
         # determine the N-dimensional lower limits
-        F = LinearNDInterpolator(z, dat)
-        points = np.reshape(np.array([datlimz, datlim[:, 0]]),
-                            [numlim, ndim+1])
-        lim1 = F(points)
+        F = LinearNDInterpolator(datlimz, datlim[:, 0].reshape(numlim, 1))
+        lim1 = F(z).reshape(dat.size)
+
         # Compute Delaunay Triangulation and use linear interpolation to
         # determine the N-dimensional upper limits
-        F = LinearNDInterpolator(z, dat)
-        points = np.reshape(np.array([datlimz, datlim[:, 1]]),
-                            [numlim, ndim+1])
-        lim2 = F(points)
+        F = LinearNDInterpolator(datlimz, datlim[:, 1].reshape(numlim, 1))
+        lim2 = F(z).reshape(dat.size)
 
     # replace NaNs from above interpolations
     ff = (np.isnan(lim1)) | (np.isnan(lim2))


### PR DESCRIPTION
The following test data and corrected code appears to work as expected. Need PS feedback and creation of a test data set for this test to validate.

``` python
In [200]: dat
Out[200]: 
array([ 15.26960509,   5.71108009,   0.43544324,  10.55281782,
         5.12354043,   6.47915889,   8.83169881,  10.52181005,
         9.98162102,  17.24717994,  12.98539626,  11.49437131,
        19.94220529,  15.29511617,  11.67751821,   5.68430577,
        16.03461491,  17.16254602,  23.42698355,  21.25758279,
        10.72212873,   2.49786004,   3.24159065,  16.49689228,
         3.19794945,   8.11150919,   0.07678312,  19.6907902 ,
        22.13641109,   5.57761618])

In [201]: z
Out[201]: 
array([[ 478.32537135,  149.52486997],
       [ 739.99307344,  236.90752747],
       [ 249.92549728,  328.32674443],
       [ 513.73364781,  272.51229415],
       [ 256.58557656,  223.85302291],
       [  15.9771266 ,  228.55563121],
       [ 942.69972683,  360.27874773],
       [ 504.9082821 ,  321.62840964],
       [ 290.59314483,  143.89572433],
       [ 874.07442538,  142.08077946],
       [ 826.16613912,  223.95151408],
       [ 400.9963074 ,  339.42089594],
       [ 947.60037093,   20.13867879],
       [ 952.51778404,   39.17377645],
       [ 258.18161422,  345.83572146],
       [ 838.81506541,  178.84226085],
       [  36.03264723,   18.55232013],
       [ 476.7145391 ,  283.96574387],
       [ 118.06159666,  144.53462972],
       [ 445.37643623,   17.05189551],
       [ 640.16849856,  163.97982946],
       [ 482.74405321,  230.95455548],
       [ 233.20887866,   86.83240371],
       [ 250.0344456 ,  325.2375387 ],
       [ 446.59365292,   62.677601  ],
       [ 410.06555398,  130.9039463 ],
       [ 290.42602663,  148.54011865],
       [ 110.70588426,   38.29885687],
       [ 684.44677953,  353.53569601],
       [ 453.85786596,  307.26061716]])

In [202]: datlim
Out[202]: 
array([[ 0, 25],
       [ 0, 25],
       [ 0, 20],
       [ 4, 15],
       [ 5, 13],
       [ 7, 10]])

In [203]: datlimz
Out[203]: 
array([[   5,    0],
       [  10,   30],
       [ 250,   60],
       [ 500,   60],
       [ 750,   60],
       [1000,  180]])

In [204]: 

In [204]: numlim =6

In [205]: ndim = 2

In [206]: %paste
    # calculate the upper and lower limits for the data set
    if ndim == 1:
        # determine the lower limits using linear interpolation
        lim1 = np.interp(z, datlimz, datlim[:, 0], left=np.nan, right=np.nan)
        # determine the upper limits using linear interpolation
        lim2 = np.interp(z, datlimz, datlim[:, 1], left=np.nan, right=np.nan)
    else:
        # Compute Delaunay Triangulation and use linear interpolation to
        # determine the N-dimensional lower limits
        F = LinearNDInterpolator(datlimz, datlim[:, 0].reshape(numlim, 1))
        lim1 = F(z).reshape(dat.size)

        # Compute Delaunay Triangulation and use linear interpolation to
        # determine the N-dimensional upper limits
        F = LinearNDInterpolator(datlimz, datlim[:, 1].reshape(numlim, 1))
        lim2 = F(z).reshape(dat.size)

    # replace NaNs from above interpolations
    ff = (np.isnan(lim1)) | (np.isnan(lim2))
    lim1[ff] = np.max(datlim[:, 1])
    lim2[ff] = np.min(datlim[:, 0])

    # compute the qcflags
    qcflag = (dat >= lim1) & (dat <= lim2)

## -- End pasted text --

In [207]: qcflag
Out[207]: 
array([False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False, False,  True, False,
       False, False, False, False, False, False,  True, False, False,
        True, False, False], dtype=bool)

In [208]: qcflag.astype('int8')
Out[208]: 
array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
       0, 1, 0, 0, 1, 0, 0], dtype=int8)
```
