### PR TITLE
Fixes bug with dataqc localrangetest

### DIFF
--- a/ion_functions/qc/qc_functions.py
+++ b/ion_functions/qc/qc_functions.py
@@ -99,6 +99,22 @@ def dataqc_globalrangetest(dat, datlim, strict_validation=False):
     return (datlim.min() <= dat) & (dat <= datlim.max()).astype('int8')
 
 def dataqc_localrangetest_wrapper(dat, datlim, datlimz, dims, pval_callback):
+    if is_none(datlim) or is_fill(datlim):
+        out = np.empty(dat.shape, dtype=np.int8)
+        out.fill(-99)
+        return out
+    if is_none(datlimz) or is_fill(datlimz):
+        out = np.empty(dat.shape, dtype=np.int8)
+        out.fill(-99)
+        return out
+    if is_none(dims):
+        out = np.empty(dat.shape, dtype=np.int8)
+        out.fill(-99)
+        return out
+    if is_none(pval_callback):
+        out = np.empty(dat.shape, dtype=np.int8)
+        out.fill(-99)
+        return out
 
     z = []
     for dim in dims:


### PR DESCRIPTION
Adds parameter checks so that if a None squeaks by then it just returns all -99s instead of raising an exception, which
caused really bizarre behavior in DM.

Part of [OOIION-1319](https://jira.oceanobservatories.org/tasks/browse/OOIION-1319)
