### PR TITLE
Strips outter dimension for coverage ndim variables

### DIFF
--- a/ion_functions/qc/qc_functions.py
+++ b/ion_functions/qc/qc_functions.py
@@ -191,6 +191,12 @@ def dataqc_localrangetest(dat, z, datlim, datlimz, strict_validation=False):
             if not utils.isreal(arg).all():
                 raise ValueError('\'{0}\' must be real'.format(k))
 
+    if len(datlim.shape) == 3 and datlim.shape[0] == 1:
+        datlim = datlim.reshape(datlim.shape[1:])
+
+    if len(datlimz.shape) == 3 and datlimz.shape[0] == 1:
+        datlimz = datlimz.reshape(datlimz.shape[1:])
+
     # test size and shape of the input arrays datlimz and datlim, setting test
     # variables.
     array_size = datlimz.shape


### PR DESCRIPTION
The coverage returns the outter dimension in-tact for higher-dimension variable lenght arrays, this patch strips the
outter-dimension for when the length of the outter dimension is 1.

Part of [OOIION-1310](https://jira.oceanobservatories.org/tasks/browse/OOIION-1310)
