### PR TITLE
Removes bad imports

### DIFF
--- a/ion_functions/data/vel_functions.py
+++ b/ion_functions/data/vel_functions.py
@@ -12,8 +12,7 @@
 import numpy as np
 import numexpr as ne
 
-from ion_functions.data.adcp_functions import adcp_magvar
-from ion_functions.data.generic_functions import magnetic_declination, wmm_model
+from ion_functions.data.generic_functions import wmm_model
 from ion_functions.data.wmm import WMM
 
 


### PR DESCRIPTION
The reworking of the adcp functions renamed a method which caused loading this module to break and therefore break some integration tests of the VEL3D instrument in ION.

https://github.com/ooici/ion-functions/pull/77
