### PR TITLE
CIDEVMI-1019 Adds the scattering coefficient of seawater

### DIFF
--- a/ion_functions/data/README.txt
+++ b/ion_functions/data/README.txt
@@ -7,25 +7,29 @@ according to its Instrument Family as defined in SAF.
         
 Conductivity, Temperature, Depth (CTD)
 
-     * ctd_functions.py -- Covers calculation of the L1 CONDWAT, TEMPWAT and
-       PRESWAT data products, and the L2 PRACSAL and DENSITY data products.
-       This module includes the following functions:
-       
-       ctd_sbe16plus_condwat -- calculates CONDWAT_L1 from CTDBP(CDEFNO) and CTDPF(AB)
-       ctd_sbe16plus_tempwat -- calculates TEMPWAT_L1 from CTDBP(CDEFNO) and CTDPF(AB)
-       ctd_sbe16plus_preswat -- calculates PRESWAT_L1 from CTDBP(CDEF) and CTDPF(AB)
-       ctd_sbe16digi_preswat -- calculates PRESWAT_L1 from CTDBP(N and O series) only
-       ctd_sbe37im_condwat   -- calculates CONDWAT_L1 from CTDMO all series (GHQR) 
-       ctd_sbe37im_tempwat   -- calculates TEMPWAT_L1 from CTDMO all series (GHQR) 
-       ctd_sbe37im_preswat   -- calculates PRESWAT_L1 from CTDMO all series (GHQR) 
-       ctd_sbe52mp_condwat   -- calculates CONDWAT_L1 from CTDPF all series (CKL)
-       ctd_sbe52mp_tempwat   -- calculates TEMPWAT_L1 from CTDPF all series (CKL)
-       ctd_sbe52mp_preswat   -- calculates PRESWAT_L1 from CTDPF all series (CKL)
-       ctd_pracsal -- calculates PRACSAL_L2 from all CTDs
-       ctd_density -- calculates DENSITY_L2 from all CTDs
-       
-       CTDAV (all series) and CTDGV (all series) produce the L1 data products
-       directly. CTDPF (series J,O,R) are unassigned as of 2014-02-17.
+        * ctd_functions.py -- Covers calculation of the L1 CONDWAT, TEMPWAT and
+          PRESWAT data products, and the L2 PRACSAL and DENSITY data products.
+          This module includes the following functions:
+          
+          ctd_sbe16plus_condwat -- calculates CONDWAT_L1 from CTDBP(CDEFNO) and
+                CTDPF(AB)
+          ctd_sbe16plus_tempwat -- calculates TEMPWAT_L1 from CTDBP(CDEFNO) and
+                CTDPF(AB)
+          ctd_sbe16plus_preswat -- calculates PRESWAT_L1 from CTDBP(CDEF) and
+                CTDPF(AB)
+          ctd_sbe16digi_preswat -- calculates PRESWAT_L1 from CTDBP(N and O
+                series) only
+          ctd_sbe37im_condwat   -- calculates CONDWAT_L1 from CTDMO all series
+          ctd_sbe37im_tempwat   -- calculates TEMPWAT_L1 from CTDMO all series
+          ctd_sbe37im_preswat   -- calculates PRESWAT_L1 from CTDMO all series
+          ctd_sbe52mp_condwat   -- calculates CONDWAT_L1 from CTDPF all series
+          ctd_sbe52mp_tempwat   -- calculates TEMPWAT_L1 from CTDPF all series
+          ctd_sbe52mp_preswat   -- calculates PRESWAT_L1 from CTDPF all series
+          ctd_pracsal -- calculates PRACSAL_L2 from all CTDs
+          ctd_density -- calculates DENSITY_L2 from all CTDs
+          
+          CTDAV (all series) and CTDGV (all series) produce the L1 data
+          products directly.
        
 Fluorometer (FLO)
 
@@ -36,6 +40,9 @@ Fluorometer (FLO)
           ### Core functions
           flo_bback_total -- calculates FLUBSCT-BBACK_L1 from FLORT and FLORD
                 (all series)
+          flo_scat_seawater -- calculates the scattering coefficient of
+                seawater from Zhang et al 2009, a required metadata parameter
+                for FLUBSCT
           flo_beta -- calculates FLUBSCT-BETA_L1 from FLORT and FLORD
                 (all series)
           flo_cdom -- calculates CDOMFLO_L1 from FLORT (all series)
@@ -107,91 +114,94 @@ Optical Properties (OPT)
 
 Partial Pressure CO2 (CO2)
 
-     * co2_functions.py -- Covers calculation of the L1 PCO2WAT data product
-       and extraction of the associated L0 data products.
-       
-       [TODO: Fill out with module names and descriptions]
-       pco2_abs434_ratio
-       pco2_abs620_ratio
-       pco2_abs434_blank
-       pco2_abs620_blank
-       pco2_thermistor
-       pco2_pco2wat
-       pco2_calc_pco2
+        * co2_functions.py -- Covers calculation of the L1 PCO2WAT data product
+          and extraction of the associated L0 data products.
+          
+          [TODO: Fill out with module names and descriptions]
+          pco2_abs434_ratio
+          pco2_abs620_ratio
+          pco2_abs434_blank
+          pco2_abs620_blank
+          pco2_thermistor
+          pco2_pco2wat
+          pco2_calc_pco2
      
 pH (pH)
 
-     * ph_functions.py -- Covers calculation of the L1 PHWATER data product
-       and extraction of the associated L0 data products.
-       
-       [TODO: Fill out with module names and descriptions]
-       ph_434_intensity
-       ph_578_intensity
-       ph_thermistor
-       ph_phwater
+        * ph_functions.py -- Covers calculation of the L1 PHWATER data product
+          and extraction of the associated L0 data products.
+          
+          [TODO: Fill out with module names and descriptions]
+          ph_434_intensity
+          ph_578_intensity
+          ph_thermistor
+          ph_phwater
 
 Seafloor Pressure (PRS)
 
-     * prs_functions -- Covers calculation of the L1 data products collected
-       from the BOTPT (BOTTILT), PRESF and PREST (both SFLPRES) instruments.
-       Note, functions for PRESF and PREST are implemented as Preload
-       ParameterFunctions, rather than herein. Also, no function is required
-       for the BOTPRES_L1 data product, as that value is output directly by the
-       instrument.
-       
-       prs_bottilt_ccmp -- computes the BOTTILT-CCMP_L1 data product
-       prs_bottilt_tmag -- computes the BOTTILT-TMAG_L1 data product
-       prs_bottilt_tdir -- computes the BOTTILT-TDIR_L1 data product
+        * prs_functions -- Covers calculation of the L1 data products collected
+          from the BOTPT (BOTTILT), PRESF and PREST (both SFLPRES) instruments.
+          Note, functions for PRESF and PREST are implemented as Preload
+          ParameterFunctions, rather than herein. Also, no function is required
+          for the BOTPRES_L1 data product, as that value is output directly by
+          the instrument.
+          
+          prs_bottilt_ccmp -- computes the BOTTILT-CCMP_L1 data product
+          prs_bottilt_tmag -- computes the BOTTILT-TMAG_L1 data product
+          prs_bottilt_tdir -- computes the BOTTILT-TDIR_L1 data product
        
 Seafloor Properties (SFL)
 
-     * sfl_functions.py -- Covers calculation of L1 data products collected
-       from the TRHPH instrument (TRHPHTE, TRHPHCC, TRHPHEH)
-       
-       sfl_trhph_vfltemp -- computes the TRHPHTE_L1 data product
-       sfl_trhph_chloride -- computes the TRHPHCC_L2 data product
-       sfl_trhph_vflorp -- computes the TRHPHEH_L1 data product
-       sfl_trhph_vfl_thermistor_temp -- computes a diagnostic data product,
-           which, however, is not a core data product.
-         
-     * sfl_functions_surface.py -- Recreates the 3 arrays of temperature
-       (tdat), conductivty (sdat) and chloride (cdat) from the Larson et al
-       2007 derived calibration surface provided to CI in a Matlab file
-       (Larson_2007surface.mat). 
+        * sfl_functions.py -- Covers calculation of L1 data products collected
+          from the TRHPH instrument (TRHPHTE, TRHPHCC, TRHPHEH)
+          
+          sfl_trhph_vfltemp -- computes the TRHPHTE_L1 data product
+          sfl_trhph_chloride -- computes the TRHPHCC_L2 data product
+          sfl_trhph_vflorp -- computes the TRHPHEH_L1 data product
+          sfl_trhph_vfl_thermistor_temp -- computes a diagnostic data product,
+              which, however, is not a core data product.
+            
+        * sfl_functions_surface.py -- Recreates the 3 arrays of temperature
+          (tdat), conductivty (sdat) and chloride (cdat) from the Larson et al
+          2007 derived calibration surface provided to CI in a Matlab file
+          (Larson_2007surface.mat). 
           
 Water Velocity (VEL)
 
-     * adcp_functions.py -- Covers calculation of the L1 VELPROF and ECHOINT
-       data products from ADCPs. This module includes:
-       
-       adcp_beam_eastward
-       adcp_beam_northward
-       adcp_beam_vertical
-       adcp_beam_error
-       adcp_earth_eastward
-       adcp_earth_northward
-       adcp_beam2ins
-       adcp_ins2earth
-     
-     * vel_functions.py -- Covers calculation of the L1 VEL3D Eastward
-       and Northward component data products from the VEL3D-B, VEL3D-CD,
-       VEL3D-K, and VELPT instruments.  This module includes
-     
-       nobska_mag_corr_east -- calculates VELPTTU-VLE_L1 from VEL3D-Bs (Nobska)
-       nobska_mag_corr_north -- calculates VELPTTU-VLN_L1 from VEL3D-Bs (Nobska)
-       nobska_scale_up_vel -- calculates VELPTTU-VLU_L0 from VEL3D-Bs (Nobska)
-       nortek_mag_corr_east -- calculates VELPTTU-VLE_L1 from VEL3D-CDKs & VELPTs (Nortek)
-       nortek_mag_corr_north -- calculates VELPTTU-VLN_L1 from VEL3D-CDKs & VELPTs (Nortek)
-       nortek_up_vel -- passes through VELPTTU-VLU_L1 from VEL3D-CDKs & VELPTs (Nortek)
+        * adcp_functions.py -- Covers calculation of the L1 VELPROF and ECHOINT
+          data products from ADCPs. This module includes:
+          
+          adcp_beam_eastward
+          adcp_beam_northward
+          adcp_beam_vertical
+          adcp_beam_error
+          adcp_earth_eastward
+          adcp_earth_northward
+          adcp_beam2ins
+          adcp_ins2earth
+        
+        * vel_functions.py -- Covers calculation of the L1 VEL3D Eastward
+          and Northward component data products from the VEL3D-B, VEL3D-CD,
+          VEL3D-K, and VELPT instruments.  This module includes
+        
+          nobska_mag_corr_east -- calculates VELPTTU-VLE_L1 from VEL3D-B
+          nobska_mag_corr_north -- calculates VELPTTU-VLN_L1 from VEL3D-B
+          nobska_scale_up_vel -- calculates VELPTTU-VLU_L0 from VEL3D-B
+          nortek_mag_corr_east -- calculates VELPTTU-VLE_L1 from VEL3D-CDK &
+                VELPT
+          nortek_mag_corr_north -- calculates VELPTTU-VLN_L1 from VEL3D-CDK &
+                VELPT
+          nortek_up_vel -- passes through VELPTTU-VLU_L1 from VEL3D-CDK &
+                VELPT
        
 Meteorology (MET)
 
-     * met_functions.py -- Covers calculation of the L1 WINDAVG Eastward
-       and Northward component data products from METBK instruments.
-       This module includes:
-       
-       windavg_mag_corr_east -- calculates WINDAVG-VLE_L1 from METBKs
-       windavg_mag_corr_north -- calculates WINDAVG-VLN_L1 from METBKs
+        * met_functions.py -- Covers calculation of the L1 WINDAVG Eastward
+          and Northward component data products from METBK instruments.
+          This module includes:
+          
+          windavg_mag_corr_east -- calculates WINDAVG-VLE_L1 from METBKs
+          windavg_mag_corr_north -- calculates WINDAVG-VLN_L1 from METBKs
 
 Additional Functions, available in generic_functions.py, provide for transforms
 and calculations that apply to multiple instrument families.

--- a/ion_functions/data/flo_functions.py
+++ b/ion_functions/data/flo_functions.py
@@ -80,6 +80,45 @@ def flo_bback_total(beta, degC=20.0, psu=32.0, theta=117.0, wlngth=700.0,
     return bback
 
 
+def flo_scat_seawater(degC, psu, theta=117.0, wlngth=700.0, delta=0.039):
+    """
+    Description:
+
+        Computes the scattering coefficient of seawater based on the
+        computation of Zhang et al 2009 as presented in the DPS for Optical
+        Backscatter (red wavelengths).
+
+    Implemented by:
+
+        2014-04-24: Christopher Wingard. Initial Code
+
+    Usage:
+
+        bsw = flo_scat_seawater(degC, psu, theta, wlngth, delta)
+
+            where
+
+        bsw = total scattering coefficient of pure seawater [m-1]
+        degC = in situ water temperature from co-located CTD [deg_C]
+        psu = in situ salinity from a co-located CTD [psu]
+        theta = optical backscatter angle [degrees]. All OOI FLORT
+            and FLORD instruments use 117 degrees.
+        wlngth = optical backscatter measurement wavelength [nm]. All OOI FLORT
+            and FLORD instruments use 700 nm.
+        delta = depolarization ratio [unitless]. Default of 0.039 is assumed.
+
+    References:
+
+        OOI (2012). Data Product Specification for Optical Backscatter (Red
+            Wavelengths). Document Control Number 1341-00540.
+            https://alfresco.oceanobservatories.org/ (See: Company Home >>
+            OOI >> Controlled >> 1000 System Level >>
+            1341-00540_Data_Product_SPEC_FLUBSCT_OOI.pdf)
+    """
+    betasw, bsw = flo_zhang_scatter_coeffs(degC, psu, theta, wlngth, delta)
+    return bsw
+
+
 def flo_zhang_scatter_coeffs(degC, psu, theta=117.0, wlngth=700.0, delta=0.039):
     """
     Description:


### PR DESCRIPTION
Adds the scattering coefficient of seawater as a discrete function to call in order to create the required metadata parameter for use with the FLUBSCT data product.
