### PR TITLE
Deploy any WMM COF files present

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(name = 'ion-functions',
             'scipy==0.11.0',
             'cython'
         ],
-        package_data = {'ion_functions.data':['WMM.COF']},
+        package_data = {'ion_functions.data':['WMM*.COF']},
 
 )
 


### PR DESCRIPTION
The set_wmm_model method will select which coefficients file to use (currently only 2010 present), but only a file specifically name WMM.COF will currently be deployed when ion_functions is installed. This change will deploy any coefficient files in the data directory.