### PR TITLE
fixed nutnr (#2942) and dosta (#2972) for time-vectorized calcoeffs.

### DIFF
--- a/ion_functions/data/adcp_functions.py
+++ b/ion_functions/data/adcp_functions.py
@@ -1235,6 +1235,8 @@ def magnetic_correction(theta, u, v):
                     calculate magnetic corrections by the functions contained
                     in this module instead of the function magnetic_correction
                     found in ion_functions.data.generic_functions.
+        2015-04-10: Russell Desiderio. Corrected a typo:
+                    uv = np.atleast_2d(u)  ->  u = np.atleast_2d(u)
 
     Usage:
 
@@ -1268,7 +1270,7 @@ def magnetic_correction(theta, u, v):
     """
     # force shapes of inputs to arrays
     theta = np.atleast_1d(theta)
-    uv = np.atleast_2d(u)
+    u = np.atleast_2d(u)
     v = np.atleast_2d(v)
 
     theta_rad = np.radians(theta)

--- a/ion_functions/data/do2_functions.py
+++ b/ion_functions/data/do2_functions.py
@@ -54,6 +54,12 @@ def do2_SVU(calphase, temp, csv):
 
     Implemented by:
         2013-04-26: Stuart Pearce. Initial Code.
+        2015-04-10: Russell Desiderio. Revised code to work with CI implementation
+                    of calibration coefficients: they are to be implemented as time-
+                    vectorized arguments (tiled in the time dimension to match the
+                    number of data packets).
+
+                    Fix for "blocker bug #2972".
 
     References:
         OOI (2012). Data Product Specification for Oxygen Concentration
@@ -62,11 +68,13 @@ def do2_SVU(calphase, temp, csv):
             Company Home >> OOI >> Controlled >> 1000 System Level
             >> 1341-00520_Data_Product_SPEC_DOCONCS_OOI.pdf)
     """
+    # this will work for both old and new CI implementations of cal coeffs.
+    csv = np.atleast_2d(csv)
 
     # Calculate DO using Stern-Volmer:
-    Ksv = csv[0] + csv[1]*temp + csv[2]*(temp**2)
-    P0 = csv[3] + csv[4]*temp
-    Pc = csv[5] + csv[6]*calphase
+    Ksv = csv[:, 0] + csv[:, 1]*temp + csv[:, 2]*(temp**2)
+    P0 = csv[:, 3] + csv[:, 4]*temp
+    Pc = csv[:, 5] + csv[:, 6]*calphase
     DO = ((P0/Pc) - 1) / Ksv
     return DO
 

--- a/ion_functions/data/opt_functions.py
+++ b/ion_functions/data/opt_functions.py
@@ -745,6 +745,8 @@ def opt_par_wetlabs(counts_output, a0, a1, Im):
     Implemented by:
 
         2014-12-10: Craig Risien. Initial Code
+        2015-04-09: Russell Desiderio. Fixed "blocker bug #3182" so that the
+                    function runs correctly on time-vectorized arguments.
 
     Usage:
 
@@ -892,7 +894,8 @@ def opt_ocr507_irradiance(counts, offset, scale, immersion_factor):
             Changed code to require data input arguments to be arrays with 7 columns,
             one for each wavelength channel.
         2015-04-09: Russell Desiderio
-            CI has determined that cal coefficients will be tiled in time.
+            CI has determined that cal coefficients will be implemented as time-vectorized
+            arguments (tiled in time to the number of data packets).
 
     Usage:
 

--- a/ion_functions/data/test/test_do2_functions.py
+++ b/ion_functions/data/test/test_do2_functions.py
@@ -30,6 +30,9 @@ class TestDo2FunctionsUnit(BaseUnitTestCase):
         SBE43F oxygen sensors are connected to a SBE 52-MP profiling CTD
         which provides the inputs of salinity, temperature, and
         pressure.
+
+        2015-04-10: Russell Desiderio. Added test for implementation of
+                    calibration coefficients as time-vectorized arguments.
         """
 
         # FUNCTION CALIBRATION COEFFICIENTS
@@ -106,6 +109,23 @@ class TestDo2FunctionsUnit(BaseUnitTestCase):
         #np.testing.assert_allclose(do_int, do_int_expected, rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(do, do_expected, rtol=1e-6, atol=1e-6)
 
+        # R. Desiderio, 10-Apr-2015:
+        # test new CI implementation of time-vectorized cal coeffs
+        tval = freq.shape[0]
+        A = np.tile(A, tval)
+        B = np.tile(B, tval)
+        C = np.tile(C, tval)
+        E = np.tile(E, tval)
+        Foffset = np.tile(Foffset, tval)
+        Soc = np.tile(Soc, tval)
+
+        # CALCULATION
+        do = do2_dofst_frequency(
+            freq, Foffset, Soc, A, B, C, E, pres, temp, salt, lat, lon)
+
+        # ASSERT FINAL OUTPUTS
+        np.testing.assert_allclose(do, do_expected, rtol=1e-6, atol=1e-6)
+
     def test_dofst_voltage(self):
         """ DOFST voltage test
         Unit Test of the do2_dofst_volt function in
@@ -115,6 +135,9 @@ class TestDo2FunctionsUnit(BaseUnitTestCase):
         NOTE:
         SBE43 oxygen sensors are connected to a SBE 16+ V2 CTD which
         provides the inputs of salinity, temperature, and pressure.
+
+        2015-04-10: Russell Desiderio. Added test for implementation of
+                    calibration coefficients as time-vectorized arguments.
         """
 
         # FUNCTION CALIBRATION COEFFICIENTS
@@ -189,6 +212,23 @@ class TestDo2FunctionsUnit(BaseUnitTestCase):
         #np.testing.assert_allclose(do_int, do_int_expected, rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(do, do_expected, rtol=1e-6, atol=1e-6)
 
+        # R. Desiderio, 10-Apr-2015:
+        # test new CI implementation of time-vectorized cal coeffs
+        tval = volt_counts.shape[0]
+        A = np.tile(A, tval)
+        B = np.tile(B, tval)
+        C = np.tile(C, tval)
+        E = np.tile(E, tval)
+        Voffset = np.tile(Voffset, tval)
+        Soc = np.tile(Soc, tval)
+
+        # CALCULATION
+        do = do2_dofst_volt(
+            volt_counts, Voffset, Soc, A, B, C, E, pres, temp, salt, lat, lon)
+
+        # ASSERT FINAL OUTPUTS
+        np.testing.assert_allclose(do, do_expected, rtol=1e-6, atol=1e-6)
+
     def test_do2_SVU(self):
         """ DOSTA Stern-Volmer-Uchida (SVU) test
         Unit Test of the do2_SVU function in
@@ -196,6 +236,9 @@ class TestDo2FunctionsUnit(BaseUnitTestCase):
         oxygen with the SVU equation from phase, temperature, and
         multipoint calibration coefficients from a Aanderaa oxygen
         optode.
+
+        2015-04-10: Russell Desiderio. Added test for implementation of
+                    calibration coefficients as time-vectorized arguments.
         """
         calphase = np.array([
             32., 32., 32., 32., 39.825, 39.825, 39.825,
@@ -228,11 +271,24 @@ class TestDo2FunctionsUnit(BaseUnitTestCase):
         # SVU ASSERT
         np.testing.assert_array_almost_equal(do_svu, svu_expected, decimal=6)
 
+        # R. Desiderio, 10-Apr-2015:
+        # test new CI implementation of time-vectorized cal coeffs
+        tval = calphase.shape[0]
+        csv = np.tile(csv, (tval, 1))
+
+        # SVU CALCULATION
+        do_svu = do2_SVU(calphase, temp, csv)
+
+        # SVU ASSERT
+        np.testing.assert_array_almost_equal(do_svu, svu_expected, decimal=6)
+
     def test_salinity_correction(self):
         """ DOSTA salinity correction test
         Unit Test of the do2_salinity_correction function in
         ion_functions/data/do2_functions.py for correction of
         oxygen for pressure and salinity.
+
+        2015-04-10: Russell Desiderio. No cal in this function's argument list.
         """
         do_svu = np.array([
             3.67038772e+02,   2.89131248e+02,   2.32138540e+02,

--- a/ion_functions/data/test/test_nit_functions.py
+++ b/ion_functions/data/test/test_nit_functions.py
@@ -30,6 +30,9 @@ class TestNitFunctionsUnit(BaseUnitTestCase):
             1341-00620_Data_Product_Spec_NUTNR_OOI.pdf)
 
         Implemented by Craig Risien, May 2014
+        Revised by Russell Desiderio, April 09, 2015.
+            Cal coeffs are now presented as time-vectorized arguments as input to the DPAs.
+            The DPA and unit tests have been revised to incorporate this change.
         """
 
     # test inputs
@@ -111,9 +114,28 @@ class TestNitFunctionsUnit(BaseUnitTestCase):
 
     # expected outputs
     nit_expected = np.array([-9999999.0, -9999999.0, -9999999.0, -9999999.0, -9999999.0, 0.75987271, 0.87556255, 0.96985023, 1.08586070, 0.88144169, -9999999.0, 1.00141440, 0.75700846, 1.16804700, 0.90545067, 0.80298560, -9999999.0, -3.94501510, -9999999.0, -4.12437310, -9999999.0, -4.04031150, -4.39287360, -3.80415850, -3.85723530, -4.24619420, -9999999.0, -3.99834040, -4.11579830, -4.00934960, -4.52545540, -3.80571640, -9999999.0, 27.05594900, -9999999.0, 27.43379400, -9999999.0, 28.29888200, 27.70576900, 27.50978800, 28.17723100, 27.16895500, -9999999.0, 27.83870300, 28.26505800, 27.20442100, 27.32593200, 27.79936600, -9999999.0, 0.35236329, -9999999.0, 0.69892011, -9999999.0, 0.44256863, 0.51434485, 0.41167468, 0.32718955, 0.36115907, -9999999.0, 0.44321778, 0.54636823, 0.59245404, 0.36121940, 0.64607541])
-    # compute L2 nit conc values
+    # change fill values to nans.
+    nit_expected[nit_expected == -9999999.0] = np.nan
+
+    # compute L2 nit conc values: cal coeffs are time-vectorized.
+    # wllower and wlupper omitted from input arguments
+    tval = data_in.shape[0]
+    cal_temp = np.tile(cal_temp, tval)
+    wl = np.tile(wl, (tval, 1))
+    eno3 = np.tile(eno3, (tval, 1))
+    eswa = np.tile(eswa, (tval, 1))
+    di = np.tile(di, (tval, 1))
+
     NO3_conc_calc = ts_corrected_nitrate(cal_temp, wl, eno3, eswa, di, dark_value,
                                          ctd_t, ctd_sp, data_in, frame_type)
-
     # compare calculated results to expected results
     np.testing.assert_allclose(NO3_conc_calc, nit_expected, rtol=0.000001, atol=0.000001)
+
+    # test when wllower and wlupper are included in the argument list
+    wllower = np.tile(217.0, tval)
+    wlupper = np.tile(240.0, tval)
+    NO3_conc_calc = ts_corrected_nitrate(cal_temp, wl, eno3, eswa, di, dark_value,
+                                         ctd_t, ctd_sp, data_in, frame_type, wllower, wlupper)
+    # compare calculated results to expected results
+    np.testing.assert_allclose(NO3_conc_calc, nit_expected, rtol=0.000001, atol=0.000001)
+

--- a/ion_functions/data/test/test_opt_functions.py
+++ b/ion_functions/data/test/test_opt_functions.py
@@ -759,7 +759,7 @@ class TestOptFunctionsUnit(BaseUnitTestCase):
         Modified by Russell Desiderio, March 25, 2014.
             Transposed test array.
             Set known output to be 2D row vector.
-        Modified by Russell Desiderio, April 09, 2014.
+        Modified by Russell Desiderio, April 09, 2015.
             Added unit tests for multiple data packets and exception checking
             Set known output for 1 data packet case to be 1D vector.
         """


### PR DESCRIPTION
fixes u-frame blocker #s as specified above.
includes new unit tests when appropriate.
changed the nutnr missing data value to np.nan instead of fill.

@s-pearce Ready for review and merge.
@cwingard Ready for review and merge.

