### PR TITLE
Issue #6359 Add versioning support to ion-functions

### DIFF
--- a/ion_functions/versioning/__init__.py
+++ b/ion_functions/versioning/__init__.py
@@ -1,0 +1,6 @@
+def version(version_number):
+    """Wrapper to add version to ion function"""
+    def decorate(f):
+        f.version = version_number
+        return f
+    return decorate


### PR DESCRIPTION
This change adds support to allow versioning of ION functions that is compatible with stream_engine. It allows functions to be decorated with the @version("x.y.z") decorator.  Once decorated the function version will be used by stream engine and placed in the provenance of products it produces. 

As an example lets say we want to version the velpt_mag_corr_east function in the vel_functions.

As a first step we import the decorator using the line: 
```python
from ion_functions.versioning import version
```
Then at the top of the function we want to add a version to we add: 

```python
 @version("42.42")
def velpt_mag_corr_east(u, v, lat, lon, timestamp, z=0.0):
     """
     Function
     """"
```

Now after reinstalling ion-functions.  Upon a request to stream engine which includes provenance, any product that uses this function will contain an entry which includes the version number:

```json
"b0ce8ec4-c88c-466b-b7fc-58bcbda69bae": {
        "function_name": "velpt_mag_corr_east",
        "function_type": "PythonFunction",
        "function_version": "42.42",
        "function_id": 106,
        "function_owner": "ion_functions.data.vel_functions",
        "argument_list": [
          "lat",
          "u",
          "v",
          "lon",
          "timestamp"
        ],
"More entries........"
}
````