### PR TITLE
"BOTPT: Added coverage thresholds for calculating L2 products"

### DIFF
--- a/ion_functions/data/test/test_prs_functions.py
+++ b/ion_functions/data/test/test_prs_functions.py
@@ -3,7 +3,7 @@
 """
 @package ion_functions.test.prs_functions
 @file ion_functions/test/test_prs_functions.py
-@author Christopher Wingard, Russell Desiderio
+@author Russell Desiderio, Chris Wingard
 @brief Unit tests for prs_functions module
 """
 
@@ -340,7 +340,7 @@ class TestPRSFunctionsUnit(BaseUnitTestCase):
                          '2011 04 30 23 59 45']
 
         reftime = mdates.date2num(dt.datetime(1900, 1, 1))
-        time15s = prsfunc.prs_botsflu_time15s(self.ss1900)
+        time15s = prsfunc.prs_botsflu_time15s(self.ss1900, self.botpres)
         # convert to datetime objects
         t15s_dto = np.array(mdates.num2date(time15s/86400.0+reftime))
         # convert 20 values to readable date-times


### PR DESCRIPTION
DPA functions with altered argument lists follow.

def prs_botsflu_time15s(timestamp, botpres):
def prs_botsflu_daydepth(timestamp, botpres, dday_coverage=0.90):
def prs_botsflu_4wkrate(timestamp, botpres, dday_coverage=0.9, rate_coverage=0.75):
def prs_botsflu_8wkrate(timestamp, botpres, dday_coverage=0.9, rate_coverage=0.75):

cf redmine ticket #4131.

@s-pearce Ready for review and merge.
@cwingard Ready for review and merge.
